### PR TITLE
Add Twitter Cards support and fix Google Analytics

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -36,7 +36,12 @@ AUTHOR WEBSITE: https://themefisher.com
   <meta property="og:image" content="{{ . | absURL }}" />
   {{ end }}
   {{ template "_internal/opengraph.html" . }}
-  {{ template "_internal/google_analytics.html" . }}
-  {{ template "_internal/google_analytics_async.html" . }}
+  {{ template "_internal/twitter_cards.html" . }}
+
+  {{ if hasPrefix .Site.GoogleAnalytics "G-" -}}
+    {{ template "_internal/google_analytics.html" . -}}
+  {{ else -}}
+    {{ template "_internal/google_analytics_async.html" . -}}
+  {{ end -}}
 
 </head>


### PR DESCRIPTION
- Add Twitter Cards Support
- Fix Google Analytics code to only include either GA4 or UA template