### PR TITLE
example site: fix error when running with latest hugo version 0.154.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ npm-debug.log
 node_modules
 builds
 package-lock.json
+.hugo_build.lock
 public
 resources

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Our showcase aims to demonstrate to the world what amazing websites people like 
 [Submit](https://gethugothemes.com/showcase?submit=show) your Omega Hugo powered website.
 
 
-<!-- licence -->
+<!-- license -->
 ## 📄License
 Copyright &copy; Designed by [Themefisher](https://themefisher.com) & Developed by
 [Gethugothemes](https://gethugothemes.com)

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -9115,7 +9115,7 @@ var bootstrap = (function (t, e, n) {
 // Licensed GPLv3 for open source use
 // or fancyBox Commercial License for commercial use
 //
-// http://fancyapps.com/fancybox/
+// https://fancyapps.com/fancybox/
 // Copyright 2017 fancyApps
 //
 // ==================================================
@@ -12052,7 +12052,7 @@ var bootstrap = (function (t, e, n) {
   })(document, window.jQuery || jQuery);
 /*
  * jquery-match-height 0.7.2 by @liabru
- * http://brm.io/jquery-match-height/
+ * https://brm.io/jquery-match-height/
  * License MIT
  */
 !(function (t) {

--- a/exampleSite/content/english/career.md
+++ b/exampleSite/content/english/career.md
@@ -53,7 +53,7 @@ career:
     form_action : "#"
     about : "With experience in creating visual directions for tech products, you are able to set the standard and lead designers along the way. You are not only able to execute beautiful user experiences yourself but communicate those concepts to the team and clients."
     experiences:
-    - "3+ years Development	experience in a startup environment"
+    - "3+ years Development experience in a startup environment"
     - "Strong knowledge of iOS, Android & Web Platforms"
     - "Dynamic presentation and communication skills"
     - "Self-motivation: You manage your own milestones, deadlines, and priorities"
@@ -63,7 +63,7 @@ career:
     form_action : "#"
     about : "With experience in creating visual directions for tech products, you are able to set the standard and lead designers along the way. You are not only able to execute beautiful user experiences yourself but communicate those concepts to the team and clients."
     experiences:
-    - "3+ years Development	experience in a startup environment"
+    - "3+ years Development experience in a startup environment"
     - "Strong knowledge of iOS, Android & Web Platforms"
     - "Dynamic presentation and communication skills"
     - "Self-motivation: You manage your own milestones, deadlines, and priorities"
@@ -74,7 +74,7 @@ career:
     form_action : "#"
     about : "With experience in creating visual directions for tech products, you are able to set the standard and lead designers along the way. You are not only able to execute beautiful user experiences yourself but communicate those concepts to the team and clients."
     experiences:
-    - "3+ years Development	experience in a startup environment"
+    - "3+ years Development experience in a startup environment"
     - "Strong knowledge of iOS, Android & Web Platforms"
     - "Dynamic presentation and communication skills"
     - "Self-motivation: You manage your own milestones, deadlines, and priorities"
@@ -85,7 +85,7 @@ career:
     form_action : "#"
     about : "With experience in creating visual directions for tech products, you are able to set the standard and lead designers along the way. You are not only able to execute beautiful user experiences yourself but communicate those concepts to the team and clients."
     experiences:
-    - "3+ years Development	experience in a startup environment"
+    - "3+ years Development experience in a startup environment"
     - "Strong knowledge of iOS, Android & Web Platforms"
     - "Dynamic presentation and communication skills"
     - "Self-motivation: You manage your own milestones, deadlines, and priorities"

--- a/exampleSite/go.sum
+++ b/exampleSite/go.sum
@@ -1,0 +1,2 @@
+github.com/gethugothemes/hugo-modules/images v0.0.0-20250112030311-a0de82520a5a h1:plU1FeSAMf40PImz/atXvreAslQv2V8iv1NUZljJXrE=
+github.com/gethugothemes/hugo-modules/images v0.0.0-20250112030311-a0de82520a5a/go.mod h1:FKliP3qOW9diIcQeLtyZ0Hdhg3PL8bdAkC/6O+XtU90=

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
   command = "hugo --minify --gc"
   
 [build.environment]
-  HUGO_VERSION = "0.147.2"
+  HUGO_VERSION = "0.154.5"
   HUGO_BASEURL = "/"
 
 [[headers]]


### PR DESCRIPTION
When running the example site with latest hugo version 0.154.5, an error is thrown:

```
ERROR error building site: assemble: failed to create page from pageMetaSource
/career: "/home/andreas/omega-hugo/exampleSite/content/english/career.md:56:70":
[55:70] value is not allowed in this context
```

This PR fixes this issue.